### PR TITLE
Check for exit status 1 and use '-' for stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This linter plugin for Linter provides an interface to [joker](https://github.co
 
 ## Installation
 
-Before using this package you will need to have [joker](https://github.com/candid82/joker) installed and available from your `$PATH`. You can download it [here](https://github.com/candid82/joker/releases) or install it via Homebrew with:
+Before using this package you will need to have [joker](https://github.com/candid82/joker) installed and available from your `$PATH`. Joker version __v0.9.7__ or greater is required. You can download it [here](https://github.com/candid82/joker/releases) or install it via Homebrew with:
 
 ```
 brew install candid82/brew/joker

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ export default {
                 : extension === ".joke" ? "--lintjoker" : "--lintclj";
 
         return helpers
-          .exec(jokerExecutablePath, [command, "--"], {
+          .exec(jokerExecutablePath, [command, "-"], {
             cwd: dirname(editorPath),
             uniqueKey: linterName,
             stdin: editorText,
@@ -71,7 +71,7 @@ export default {
 
             // console.log("linter-joker: data", data);
 
-            if (exitCode === 0 && stderr) {
+            if (exitCode === 1 && stderr) {
               const regex = /[^:]+:(\d+):(\d+): ([\s\S]+)/;
 
               const messages = stderr


### PR DESCRIPTION
Since v0.9.6 Joker exits with code 1 if there are any linter warnings or errors. Also, since Joker v0.9.7 `-` is used for stdin. `--` for stdin is deprecated and will mean something different in future versions.